### PR TITLE
Fix showcase filters bar: counts, type, search, and order-by

### DIFF
--- a/projects/app/src/app/shared/filters-bar/filters-bar.component.html
+++ b/projects/app/src/app/shared/filters-bar/filters-bar.component.html
@@ -266,17 +266,19 @@
         placeholder="any text" />
     </div>
 
-    <div class="filter-group">
-      <label for="order-by">Order by:</label>
-      <select id="order-by" [ngModel]="orderBy()" (ngModelChange)="onOrderByChange($event)">
-        <option value="date">Date</option>
-        <option value="status">Status</option>
-        <option value="author">Author</option>
-        <option value="confidence">AI Confidence</option>
-        <option value="type">Type</option>
-        <option value="preference">Preference</option>
-      </select>
-    </div>
+    @if (showOrderBy()) {
+      <div class="filter-group">
+        <label for="order-by">Order by:</label>
+        <select id="order-by" [ngModel]="orderBy()" (ngModelChange)="onOrderByChange($event)">
+          <option value="date">Date</option>
+          <option value="status">Status</option>
+          <option value="author">Author</option>
+          <option value="confidence">AI Confidence</option>
+          <option value="type">Type</option>
+          <option value="preference">Preference</option>
+        </select>
+      </div>
+    }
 
     <div class="filter-info">
       <span class="count-display">{{ filteredCount() }} / {{ totalCount() }}</span>

--- a/projects/app/src/app/shared/filters-bar/filters-bar.component.ts
+++ b/projects/app/src/app/shared/filters-bar/filters-bar.component.ts
@@ -199,6 +199,7 @@ export class FiltersBarComponent implements AfterViewInit, OnDestroy {
   totalCount = input<number>(0);
   filteredCount = input<number>(0);
   showViewToggle = input<boolean>(false);
+  showOrderBy = input<boolean>(true);
   initialState = input<FiltersBarState | null>(null);
   
   // Outputs

--- a/projects/app/src/app/showcase-ws/showcase-ws.component.html
+++ b/projects/app/src/app/showcase-ws/showcase-ws.component.html
@@ -37,6 +37,7 @@
       [totalCount]='totalPhotoCount()'
       [filteredCount]='totalPhotoCount()'
       [showViewToggle]='false'
+      [showOrderBy]='false'
       [initialState]='currentFilters()'
       (filtersChange)='onFiltersChange($event)'
       (filtersCommit)='onFiltersChange($event)'

--- a/projects/app/src/app/showcase-ws/showcase-ws.component.ts
+++ b/projects/app/src/app/showcase-ws/showcase-ws.component.ts
@@ -108,6 +108,25 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
       // Count author
       const authorId = metadata['author_id'] || 'unknown';
       authorMap.set(authorId, (authorMap.get(authorId) || 0) + 1);
+
+      // Count preference
+      const preference = metadata['favorable_future'];
+      if (preference) {
+        preferenceMap.set(preference, (preferenceMap.get(preference) || 0) + 1);
+      }
+
+      // Count potential
+      const plausibility = metadata['plausibility'];
+      if (plausibility !== null && plausibility !== undefined) {
+        const key = String(plausibility);
+        potentialMap.set(key, (potentialMap.get(key) || 0) + 1);
+      }
+
+      // Count type
+      const screenshotType = metadata['screenshot_type'];
+      if (screenshotType) {
+        typeMap.set(screenshotType, (typeMap.get(screenshotType) || 0) + 1);
+      }
     });
     
     return {
@@ -1373,7 +1392,7 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
         return;
       }
       
-      const matches = this.photoMatchesFilters(photo.metadata, filters);
+      const matches = this.photoMatchesFilters(photo, filters);
       
       if (matches) {
         // Matching item: full opacity, normal z-index
@@ -1390,7 +1409,8 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
   /**
    * Check if a photo matches the current filters
    */
-  private photoMatchesFilters(metadata: any, filters: FiltersBarState): boolean {
+  private photoMatchesFilters(photo: PhotoData, filters: FiltersBarState): boolean {
+    const metadata = photo.metadata;
     // Status filter (based on _private_moderation)
     // Only filter if not all statuses are selected (6 total statuses)
     if (filters.status.length > 0 && filters.status.length < 6) {
@@ -1420,7 +1440,19 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
       const potentialMatches = this.matchesPotentialFilter(plausibility, filters.potential);
       if (!potentialMatches) return false;
     }
-    
+
+    // Type filter (screenshot_type)
+    if (filters.type !== 'all') {
+      const screenshotType = metadata['screenshot_type'];
+      if (screenshotType !== filters.type) return false;
+    }
+
+    // Search filter
+    if (filters.search) {
+      const searchable = this.getSearchableText(photo);
+      if (!searchable.includes(filters.search.toLowerCase().trim())) return false;
+    }
+
     return true;
   }
   


### PR DESCRIPTION
## Summary

- **Filter counts**: `filterCounts()` computed was only populating status and author — now also populates preference (`favorable_future`), potential (`plausibility`), and type (`screenshot_type`)
- **Type filter**: `photoMatchesFilters()` was missing the type check entirely; now filters by `screenshot_type`
- **Full-text search**: `photoMatchesFilters()` was not applying `filters.search`; now uses `getSearchableText()` to match against all metadata fields
- **Order by**: Added `showOrderBy` input to `FiltersBarComponent` (defaults to `true`, backward-compatible); showcase passes `[showOrderBy]='false'` to hide the irrelevant dropdown

## Test plan
- [ ] Open showcase as admin and toggle the filters bar
- [ ] Verify preference, potential, and type dropdowns show non-zero counts
- [ ] Select a specific type — only matching photos should dim/highlight
- [ ] Type in the search field — only matching photos should be visible
- [ ] Confirm the "Order by" dropdown is absent in the showcase but still present in other views

🤖 Generated with [Claude Code](https://claude.com/claude-code)