### PR TITLE
Fix workspace creation token and data handling

### DIFF
--- a/projects/app/src/admin-api.service.ts
+++ b/projects/app/src/admin-api.service.ts
@@ -85,10 +85,10 @@ export class AdminApiService {
         }
         console.log('Created workspace:', workspace);
         return this.updateWorkspace(workspace.id, workspace.keys!.admin, {
-          metadata: null, 
+          metadata: null,
           public: request.public,
           collaborate: request.collaborate
-        });
+        }).pipe(map(() => workspace));
       })
     );
   }

--- a/projects/app/src/app/auth.service.ts
+++ b/projects/app/src/app/auth.service.ts
@@ -14,7 +14,7 @@ export class AuthService {
   
   constructor(private afAuth: Auth, private router: Router, private platform: PlatformService) {
     this.platform.browser(() => {
-      this.afAuth.onAuthStateChanged(user => {
+      this.afAuth.onIdTokenChanged(user => {
         this.user.next(user);
       });
       this.user.pipe(


### PR DESCRIPTION
## Summary
- Use `onIdTokenChanged` instead of `onAuthStateChanged` in `AuthService` so the Firebase token signal stays current after automatic hourly refreshes — fixes 401 errors when creating workspaces after long admin sessions
- Fix `createWorkspace()` `switchMap` to return the actual `Workspace` object instead of the generic PUT update response, so callers get the workspace id and keys

Fixes #216

## Test plan
- [ ] Log in and create a workspace — should succeed on first attempt
- [ ] Verify the console logs show the correct `Workspace` object (with `id` and `keys`)
- [ ] After an extended session (>1 hour), creating a workspace should still work without needing to refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)