### PR TITLE
Fix QR code centering on load

### DIFF
--- a/projects/app/src/app/showcase-ws/qrcode/qrcode.component.ts
+++ b/projects/app/src/app/showcase-ws/qrcode/qrcode.component.ts
@@ -14,10 +14,7 @@ export class QrcodeComponent implements AfterViewInit {
   small = input(false);
   codeSize = signal(0);
   transform = computed(() => {
-    const small = this.small();
-    const codeSize = this.codeSize();
-    const scale = this.scale();
-    return `translate(${small ? 0 : scale * codeSize / 2}px, ${small ? 0 : -scale * codeSize / 2}px) scale(${scale})`;
+    return `scale(${this.scale()})`;
   });
   scale = computed(() => {
     const mainEl = this.mainEl();


### PR DESCRIPTION
## Summary

Fixes whiletrue-industries/Chronomaps#224

The QR code's CSS transform included a `translate(scale * codeSize / 2, -scale * codeSize / 2)` that shifted it right and up from the viewport center. Since the host element already uses flexbox centering and the canvas has `transform-origin: center center`, the translate was redundant and caused the visible offset.

Removed the translate — the transform is now just `scale(...)`.

## Test plan

- [ ] Load the showcase page → verify the QR code appears centered on the viewport
- [ ] Wait for the QR code to shrink to the corner → verify it still positions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)