### PR TITLE
Fix admin bugs and showcase thumbnail/enhanced image loading

### DIFF
--- a/projects/app/src/app/admin/moderate/moderate.component.html
+++ b/projects/app/src/app/admin/moderate/moderate.component.html
@@ -125,6 +125,12 @@
             <p>{{ workspacesLoadingProgress() || 'Loading workspaces...' }}</p>
           </div>
         }
+        @if (itemsLoading() && !multiWorkspaceMode()) {
+          <div class="loading-indicator items-loading">
+            <div class="spinner"></div>
+            <p>Loading more items...</p>
+          </div>
+        }
         @if (selectedItem()) {
           <app-admin-lightbox 
             [selectedItemIndex]="selectedItemIndex()"
@@ -557,14 +563,7 @@
               />
             }
           }
-        </div>
-        
-        @if (itemsLoading() && !multiWorkspaceMode()) {
-          <div class="loading-indicator items-loading">
-            <div class="spinner"></div>
-            <p>Loading more items...</p>
-          </div>
-        }
+        </div>        
       </div>
     } @else {
       <div class="items-grid" role="list">

--- a/projects/app/src/app/admin/moderate/moderate.component.less
+++ b/projects/app/src/app/admin/moderate/moderate.component.less
@@ -1326,6 +1326,7 @@
     align-items: flex-start;
     flex: 1;
     width: 100%;
+    flex-flow: column;
 }
 
 .loading-indicator {
@@ -1913,6 +1914,7 @@
     border: 1px solid @color-primary-100;
     align-content: start;
     justify-content: start;
+    width: 100%;
 
     .thumbnail-item.select-mode {
         position: relative;
@@ -2784,7 +2786,6 @@
 // Responsive adjustments
 @media (max-width: 768px) {
     .grid-layout {
-        flex-direction: column;
         min-height: calc(100vh - 160px);
     }
 

--- a/projects/app/src/app/admin/moderate/moderate.component.ts
+++ b/projects/app/src/app/admin/moderate/moderate.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, signal, computed, inject, OnDestroy, OnInit, DestroyRef } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, signal, computed, inject, OnDestroy, OnInit, DestroyRef, untracked } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { AdminApiService } from '../../../admin-api.service';
@@ -17,7 +17,6 @@ import { firstValueFrom, catchError, of, forkJoin, take, filter, timeout } from 
 import { ImageReplacementModalComponent } from '../image-replacement-modal/image-replacement-modal.component';
 import { QrCodeModalComponent } from '../qr-code-modal/qr-code-modal.component';
 import { CommonModule } from '@angular/common';
-import { PlatformService } from '../../../platform.service';
 import { AdminLightboxComponent } from '../admin-lightbox/admin-lightbox.component';
 import { AuthService } from '../../auth.service';
 import { SkeletonLoaderComponent } from '../skeleton-loader/skeleton-loader.component';
@@ -76,6 +75,7 @@ export class ModerateComponent implements OnInit, OnDestroy {
   private auth = inject(AuthService);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
+  private authToken$ = toObservable(this.auth.token);
   
   // Single workspace mode
   workspaceId = signal<string | null>(null);
@@ -370,7 +370,7 @@ export class ModerateComponent implements OnInit, OnDestroy {
         // Initial load: reset items and load first page
         this.allFetchedItems.set([]);
         this.hasMoreItems.set(true);
-        this.loadMoreItems();
+        untracked(() => this.loadMoreItems());
       }
     });
     effect(() => {
@@ -1472,7 +1472,7 @@ export class ModerateComponent implements OnInit, OnDestroy {
       // Multi-workspace mode - wait for auth token, then load all workspaces
       this.multiWorkspaceMode.set(true);
       this.workspacesLoadingProgress.set('Authenticating…');
-      toObservable(this.auth.token).pipe(
+      this.authToken$.pipe(
         filter((token): token is string => !!token),
         take(1),
         timeout(5000),

--- a/projects/app/src/app/showcase-ws/lightbox/lightbox.component.html
+++ b/projects/app/src/app/showcase-ws/lightbox/lightbox.component.html
@@ -44,7 +44,7 @@
       <!-- Photo Content -->
       <div class='lightbox-content'>
         <img 
-          [src]='photo.screenshot_url || photo.url' 
+          [src]='photo.enhanced_url || photo.screenshot_url || photo.url'
           [alt]='"Photo " + photo.id'
           class='lightbox-image'/>
         

--- a/projects/app/src/app/showcase-ws/photo-data.ts
+++ b/projects/app/src/app/showcase-ws/photo-data.ts
@@ -13,6 +13,8 @@ export interface PhotoMetadata {
   url: string;
   created_at: string;
   screenshot_url?: string;
+  thumbnail_url?: string;
+  enhanced_url?: string;
   [key: string]: any; // Allow for additional metadata from web service
 }
 
@@ -45,6 +47,14 @@ export class PhotoData {
 
   get url(): string {
     return this._metadata.url;
+  }
+
+  get thumbnailUrl(): string {
+    return this._metadata.thumbnail_url || this._metadata.url;
+  }
+
+  get enhancedUrl(): string {
+    return this._metadata.enhanced_url || this._metadata.url;
   }
 
   get metadata(): Readonly<PhotoMetadata> {

--- a/projects/app/src/app/showcase-ws/showcase-ws.component.ts
+++ b/projects/app/src/app/showcase-ws/showcase-ws.component.ts
@@ -291,19 +291,23 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
         const photoPromises = items.map(async (item) => {
           const id = item._id;
           const placeholderUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y21DLsAAAAASUVORK5CYII=';
-          const url = item.screenshot_url || placeholderUrl;
+          const screenshotUrl = item.screenshot_url || placeholderUrl;
           if (!item.screenshot_url) {
             console.warn('[SHOWCASE_WS] Missing screenshot_url for item', id, 'using placeholder image');
           }
+          const thumbnailUrl = this.deriveThumbnailUrl(screenshotUrl);
+          const enhancedUrl = this.deriveEnhancedUrl(screenshotUrl);
           // Generate transition_bar_position if not provided by API
           const transitionBarPosition = item.transition_bar_position || this.getDefaultTransitionBarPosition(item);
           // Include all item fields to make search work across every string field
           const metadata: PhotoMetadata = {
             ...item,
             id,
-            url,
+            url: thumbnailUrl,
             created_at: item.created_at,
-            screenshot_url: url,
+            screenshot_url: screenshotUrl,
+            thumbnail_url: thumbnailUrl,
+            enhanced_url: enhancedUrl,
             layout_x: item.layout_x,
             layout_y: item.layout_y,
             plausibility: item.plausibility,
@@ -375,18 +379,22 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
           const photoPromises = newItems.map(async (item) => {
             const id = item._id;
             const placeholderUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y21DLsAAAAASUVORK5CYII=';
-            const url = item.screenshot_url || placeholderUrl;
+            const screenshotUrl = item.screenshot_url || placeholderUrl;
             if (!item.screenshot_url) {
               console.warn('[SHOWCASE_WS] Missing screenshot_url for item', id, 'using placeholder image');
             }
+            const thumbnailUrl = this.deriveThumbnailUrl(screenshotUrl);
+            const enhancedUrl = this.deriveEnhancedUrl(screenshotUrl);
             // Generate transition_bar_position if not provided by API
             const transitionBarPosition = item.transition_bar_position || this.getDefaultTransitionBarPosition(item);
             const metadata: PhotoMetadata = {
               ...item,
               id,
-              url,
+              url: thumbnailUrl,
               created_at: item.created_at,
-              screenshot_url: url,
+              screenshot_url: screenshotUrl,
+              thumbnail_url: thumbnailUrl,
+              enhanced_url: enhancedUrl,
               plausibility: item.plausibility,
               favorable_future: item.favorable_future,
               transition_bar_position: transitionBarPosition,
@@ -561,6 +569,14 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
     // Distribute evenly across the three positions
     const index = Math.abs(hash) % 3;
     return positions[index];
+  }
+
+  private deriveThumbnailUrl(screenshotUrl: string): string {
+    return screenshotUrl.replace(/screenshot\.jpeg$/, 'screenshot.thumbnail.jpeg');
+  }
+
+  private deriveEnhancedUrl(screenshotUrl: string): string {
+    return screenshotUrl.replace(/screenshot\.jpeg$/, 'screenshot.enhanced.jpeg');
   }
 
   /**

--- a/projects/app/src/app/showcase-ws/three-renderer.service.ts
+++ b/projects/app/src/app/showcase-ws/three-renderer.service.ts
@@ -136,6 +136,7 @@ export class ThreeRendererService {
   private lastClientX: number | null = null;
   private lastClientY: number | null = null;
   private meshToUrl = new Map<THREE.Mesh, string>();
+  private meshToEnhancedUrl = new Map<THREE.Mesh, string>();
   private highResActive = new Set<THREE.Mesh>();
   private lodAccumTime = 0;
 
@@ -243,8 +244,9 @@ export class ThreeRendererService {
     photoData.setMesh(mesh);
     // Track PhotoData for hover/fisheye so positions stay current after layout changes
     this.meshToPhotoData.set(mesh, photoData);
-    // Track URL for LOD decisions
+    // Track URLs for LOD decisions (thumbnail for low-res, enhanced for high-res)
     this.meshToUrl.set(mesh, photoData.url);
+    this.meshToEnhancedUrl.set(mesh, photoData.enhancedUrl);
     
     return mesh;
   }
@@ -276,6 +278,7 @@ export class ThreeRendererService {
     }
     this.meshToPhotoData.delete(photoData.mesh);
     this.meshToUrl.delete(photoData.mesh);
+    this.meshToEnhancedUrl.delete(photoData.mesh);
     const photoId = this.meshToPhotoId.get(photoData.mesh);
     if (photoId) {
       this.photoIdToMesh.delete(photoId);
@@ -2389,6 +2392,7 @@ export class ThreeRendererService {
     this.renderer?.dispose();
     this.scene?.clear();
     this.meshToUrl.clear();
+    this.meshToEnhancedUrl.clear();
     this.highResActive.clear();
     
     this.rafRunning = false;
@@ -3223,8 +3227,9 @@ export class ThreeRendererService {
       // Skip invisible meshes (culled by frustum)
       if (!mesh.visible) continue;
       
-      const url = this.meshToUrl.get(mesh);
-      if (!url) continue;
+      const thumbnailUrl = this.meshToUrl.get(mesh);
+      if (!thumbnailUrl) continue;
+      const enhancedUrl = this.meshToEnhancedUrl.get(mesh) || thumbnailUrl;
 
       const isHigh = this.highResActive.has(mesh);
 
@@ -3244,7 +3249,7 @@ export class ThreeRendererService {
 
       if (!eligibleForHighRes) {
         if (isHigh) {
-          this.downgradeToLowResTexture(mesh, url)
+          this.downgradeToLowResTexture(mesh, thumbnailUrl)
             .then(() => this.highResActive.delete(mesh))
             .catch(() => {/* keep current */});
         }
@@ -3252,13 +3257,13 @@ export class ThreeRendererService {
       }
 
       if (!isHigh && photoWidthPx >= UPGRADE_THRESHOLD) {
-        this.upgradeToHighResTexture(mesh, url)
+        this.upgradeToHighResTexture(mesh, enhancedUrl)
           .then(() => {
             this.highResActive.add(mesh);
           })
           .catch(() => {/* keep low-res */});
       } else if (isHigh && photoWidthPx <= DOWNGRADE_THRESHOLD) {
-        this.downgradeToLowResTexture(mesh, url)
+        this.downgradeToLowResTexture(mesh, thumbnailUrl)
           .then(() => {
             this.highResActive.delete(mesh);
           })


### PR DESCRIPTION
## Summary
- **Fix NG0203 error**: Moved `toObservable()` call from `ngOnInit` to a field initializer so it runs within Angular's injection context
- **Fix infinite loop**: Wrapped `loadMoreItems()` in `untracked()` inside the effect to prevent `hasMoreItems` from being tracked as a dependency, which caused an infinite reload cycle when no items were returned
- **Thumbnail/enhanced image loading**: Showcase now loads lightweight thumbnails (`screenshot.thumbnail.jpeg`) by default, and upgrades to enhanced images (`screenshot.enhanced.jpeg`) when zooming in via the existing LOD system
- **Layout fixes**: Fixed moderate grid layout and loading indicator positioning

## Test plan
- [ ] Open moderate page with an empty workspace — verify no infinite loop in console
- [ ] Open moderate page in multi-workspace mode — verify no NG0203 error
- [ ] Open showcase page — verify thumbnails load initially (check network tab for `screenshot.thumbnail.jpeg`)
- [ ] Zoom into a photo — verify enhanced image loads (`screenshot.enhanced.jpeg` in network tab)
- [ ] Zoom out — verify it downgrades back to thumbnail
- [ ] Open lightbox — verify it shows the enhanced image

🤖 Generated with [Claude Code](https://claude.com/claude-code)