### PR TITLE
Fix duplicate item creation in upload flow

### DIFF
--- a/projects/app/src/api.service.ts
+++ b/projects/app/src/api.service.ts
@@ -241,57 +241,69 @@ export class ApiService {
     );
   }
 
-  uploadImage(image: Blob, item_id: string, item_key: string): void {
+  uploadImage(image: Blob, metadata?: Record<string, any>): Observable<{ item_id: string; item_key: string }> {
     this.uploadImageInProgress.next(true);
-    this.startDiscussion(image, item_id, item_key).pipe(
-      switchMap((ret: any) => {
+    return this.startDiscussion(image).pipe(
+      map((data: any) => {
+        const item_id = data.item_id || data.metadata?.item_id;
+        const item_key = data.item_key || data.metadata?.item_key;
         this.uploadImageInProgress.next(false);
-        return this.sendInitMessageNoStream(item_id, item_key);
+        // Fire background work: apply metadata then send init message
+        const background$ = (metadata && Object.keys(metadata).length > 0)
+          ? this.updateProperties(metadata, item_id, item_key).pipe(
+              switchMap(() => this.sendInitMessageNoStream(item_id, item_key))
+            )
+          : this.sendInitMessageNoStream(item_id, item_key);
+        background$.subscribe();
+        return { item_id, item_key };
       })
-    ).subscribe((x: any) => {
-    });
-  }    
+    );
+  }
 
-  uploadImageAuto(image: Blob, item_id: string, item_key: string): Observable<any> {
+  uploadImageAuto(image: Blob, metadata?: Record<string, any>): Observable<any> {
     this.uploadImageInProgress.next(true);
-    this.startDiscussion(image, item_id, item_key).pipe(
-      tap(() => {
+    this.startDiscussion(image).pipe(
+      switchMap((data: any) => {
+        const item_id = data.item_id || data.metadata?.item_id;
+        const item_key = data.item_key || data.metadata?.item_key;
         this.uploadImageInProgress.next(false);
-        // After AI processing, save the item with preserved tags back to database
-        const currentItem = this.item();
-        if (currentItem && currentItem.tags && currentItem.tags.length > 0) {
-          console.log('[API] Saving item with preserved tags:', currentItem.tags);
-          // Send tags to database via updateItem to persist them
-          this.updateItem({ tags: currentItem.tags }, item_id, item_key).subscribe(
-            () => console.log('[API] Tags saved to database successfully'),
-            (err) => console.error('[API] Failed to save tags to database:', err)
-          );
+        if (metadata && Object.keys(metadata).length > 0) {
+          return this.updateProperties(metadata, item_id, item_key);
         }
+        return of(true);
       })
     ).subscribe(() => {
       console.log('Auto upload image complete');
     });
     return timer(2000);
-  }    
+  }
 
-  startDiscussion(image: Blob, item_id: string, item_key: string): Observable<any> {
+  startDiscussion(image: Blob, item_id?: string, item_key?: string): Observable<any> {
     const formData = new FormData();
     formData.append('image', image);
     const params: any = {
       workspace: this.workspaceId(),
       api_key: this.api_key(),
-      item_id: item_id,
-      item_key: item_key,
     };
+    if (item_id) {
+      params['item_id'] = item_id;
+    }
+    if (item_key) {
+      params['item_key'] = item_key;
+    }
     if (this.automatic()) {
       params['automatic'] = 'true';
     }
     return this.http.post(this.SCREENSHOT_HANDLER_URL, formData, { params }).pipe(
       tap((data: any) => {
         console.log('Screenshot uploaded successfully', data.metadata);
+        const item_id = data.item_id || data.metadata?.item_id;
+        const item_key = data.item_key || data.metadata?.item_key;
         this.item.update((item: any) => {
-          return Object.assign({}, item, data.metadata);
+          return Object.assign({}, item, data.metadata, { item_id, item_key });
         });
+        this.itemId.set(item_id);
+        this.itemKey.set(item_key);
       })
     );
   }

--- a/projects/app/src/app/confirm/confirm.component.ts
+++ b/projects/app/src/app/confirm/confirm.component.ts
@@ -154,33 +154,32 @@ export class ConfirmComponent {
       metadata.tags = tags;
     }
 
-    this.api.createItem(metadata).subscribe({
-      next: (res: any) => {
-        const params: any = {
-          'item-id': res.item_id,
-          'key': res.item_key
-        };
-        if (this.isTemplateFlow) {
-          params['template'] = 'true';
+    if (!this.api.automatic()) {
+      this.api.uploadImage(currentImage, metadata).subscribe({
+        next: (res) => {
+          const params: any = {
+            'item-id': res.item_id,
+            'key': res.item_key
+          };
+          if (this.isTemplateFlow) {
+            params['template'] = 'true';
+          }
+          this.router.navigate(['/props'], { queryParams: params, queryParamsHandling: 'merge' });
+        },
+        error: (error) => {
+          console.error('[CONFIRM] Failed to upload image:', error);
+          if (error.status === 403) {
+            alert('Access denied. Please check that you have the correct API key with write permissions for this workspace.');
+          } else {
+            alert('Failed to upload image. Please try again or contact support.');
+          }
         }
-        if (!this.api.automatic()) {
-          this.api.uploadImage(currentImage, res.item_id, res.item_key);
-          this.router.navigate(['/props'], { queryParams: params, queryParamsHandling: 'merge'});
-        } else {
-          this.api.uploadImageAuto(currentImage, res.item_id, res.item_key).subscribe(() => {
-            this.router.navigate(['/scan'], { queryParamsHandling: 'preserve' });
-          });
-        }
-      },
-      error: (error) => {
-        console.error('[CONFIRM] Failed to create item:', error);
-        if (error.status === 403) {
-          alert('Access denied. Please check that you have the correct API key with write permissions for this workspace.');
-        } else {
-          alert('Failed to create item. Please try again or contact support.');
-        }
-      }
-    });
+      });
+    } else {
+      this.api.uploadImageAuto(currentImage, metadata).subscribe(() => {
+        this.router.navigate(['/scan'], { queryParamsHandling: 'preserve' });
+      });
+    }
   }
 
   private uploadReplace(image: Blob, replaceItemId: string, itemKey?: string) {


### PR DESCRIPTION
## Summary
- **Eliminates `createItem` from the upload flow** — the screenshot handler (`startDiscussion`) already creates items per API docs, so calling `createItem` first was producing duplicates
- **User metadata** (tags including `no-paper`, preference, potential, textbox_content) is now applied via `updateProperties` after the screenshot handler completes
- **Replace image flow** is unaffected — it uses a separate `replaceImage` API endpoint

## Test plan
- [ ] Create a regular item (non-template) → verify only one item created, metadata applied correctly
- [ ] Create a no-paper item (template flow) → verify only one item created, has `no-paper` tag
- [ ] Test automatic mode → verify item created and auto-navigates back to scan
- [ ] Test non-automatic mode → verify navigation to `/props` with correct item_id/item_key
- [ ] Verify AI conversation init (`sendInitMessageNoStream`) still fires
- [ ] Test replace image flow → verify it still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)