### PR TITLE
Fix topic filter incorrectly hiding items when all topics are selected

### DIFF
--- a/projects/app/src/app/admin/moderate/moderate.component.ts
+++ b/projects/app/src/app/admin/moderate/moderate.component.ts
@@ -1239,6 +1239,7 @@ export class ModerateComponent implements OnInit, OnDestroy {
     potential: this.filterPotential(),
     type: this.filterType(),
     topic: this.filterTopic(),
+    totalTopicCount: this.taxonomyService.allSubThemeIds().length,
     search: this.searchText(),
     orderBy: this.orderBy(),
     view: this.viewMode()

--- a/projects/app/src/app/shared/filters-bar/filters-bar.component.ts
+++ b/projects/app/src/app/shared/filters-bar/filters-bar.component.ts
@@ -11,6 +11,7 @@ export interface FiltersBarState {
   potential: string[];
   type: string;
   topic: string[];
+  totalTopicCount?: number;
   search: string;
   orderBy: string;
   view?: string;

--- a/projects/app/src/app/shared/filters-bar/item-filter.service.ts
+++ b/projects/app/src/app/shared/filters-bar/item-filter.service.ts
@@ -67,7 +67,12 @@ export class ItemFilterService {
     }
 
     // Topic filter (filterTopic stores full sub-theme paths like "theme-id/sub-theme-id")
-    if (filters.topic && filters.topic.length > 0) {
+    // Skip when all available topics are selected (totalTopicCount matches) to avoid
+    // filtering out items whose topic values pre-date or fall outside the current taxonomy.
+    const totalTopics = filters.totalTopicCount ?? 0;
+    const isTopicSubset = filters.topic && filters.topic.length > 0 &&
+      (totalTopics === 0 || filters.topic.length < totalTopics);
+    if (isTopicSubset) {
       filtered = filtered.filter(item => {
         const topics: string[] = item.topics || [];
         // Items with no topics are always shown (taxonomy may not have tagged them yet)


### PR DESCRIPTION
## Summary

- Adds `totalTopicCount?: number` to `FiltersBarState` so `applyFilters` knows the total size of the topic universe
- `filterState` in the moderate component now forwards `taxonomyService.allSubThemeIds().length` as `totalTopicCount`
- `applyFilters` skips the topic filter when the selection equals the full available set (`topic.length >= totalTopicCount`), consistent with how preference/potential filters work

## Root cause

When all taxonomy topics were selected, `applyFilters` still ran the topic filter and silently dropped items whose `item.topics` values weren't in the current taxonomy (e.g. IDs from an older taxonomy version). This caused the flaky "68/1676" display: if taxonomy loaded before items, the filter kicked in and hid most items; if items loaded first, no filtering occurred.

## Test plan

- [ ] Open moderation view with all statuses selected — all items should show (1676/1676 or equivalent)
- [ ] Select a specific topic subset — filter should work correctly, showing only matching items
- [ ] Reload page multiple times to verify no flakiness

fixes #126