### PR TITLE
Add a TSNE view to the showcase

### DIFF
--- a/documentation/ARCHITECTURE.md
+++ b/documentation/ARCHITECTURE.md
@@ -119,16 +119,23 @@ The application uses Angular standalone components organized by feature:
 
 9. **Showcase WS** (`/showcase-ws`)
    - 3D immersive visualization using Three.js
-   - Multiple layout strategies:
-     - Grid: Random positioning in a grid
-     - TSNE / Thematic: Hex-grid layout driven by taxonomy and embedding similarity. Accessible via the **Thematic** toggle button.
-     - SVG: Interactive placement on custom background with hotspots
-     - Circle Packing: Clustered circular arrangement by group
-   - **Taxonomy overlay labels** (shown in Thematic layout):
-       - Only sub-theme labels are shown; positions are derived from taxonomy label nodes, with TSNE cluster regions as fallback when topic metadata is unavailable
+   - Layout strategies, one per button in the bottom layout toggle (hash key in parentheses):
+     - **Map** (`svg`) – interactive placement on a custom SVG background with hotspots (`SvgBackgroundLayoutStrategy`)
+     - **Thematic** (`tsne`) – hex-grid layout computed client-side from the taxonomy tree (`TaxonomyLayoutStrategy`)
+     - **TSNE** (`tsne-grid`) – the embedding precalculated server-side (`TsneLayoutStrategy`)
+     - **Clusters** (`circle-packing`) – clustered circular arrangement by group (`CirclePackingLayoutStrategy`)
+   - **Thematic layout** (`TaxonomyLayoutStrategy`):
+     - Taxonomy overlay labels: only sub-theme labels are shown; positions are derived from taxonomy label nodes, with TSNE cluster regions as fallback when topic metadata is unavailable
      - Labels update position in real-time at 60 fps using `ThreeRendererService.addFrameCallback()`
-    - TSNE fallback mapping: items missing from server TSNE grid are still positioned in Thematic layout using deterministic topic/theme centroid fallback (instead of being hidden)
-    - TSNE collision handling: all items in Thematic layout (including uncertain/non-evaluated) are assigned globally unique hexbins; collisions are resolved by nearest-free-bin deterministic hex-spiral allocation, and sub-theme label anchor bins are kept free so labels do not share a bin with a photo node
+     - Fallback mapping: items missing from the taxonomy grid are still positioned, using a deterministic topic/theme centroid fallback (instead of being hidden)
+     - Collision handling: all items (including uncertain/non-evaluated) are assigned globally unique hexbins; collisions are resolved by nearest-free-bin deterministic hex-spiral allocation, and sub-theme label anchor bins are kept free so labels do not share a bin with a photo node
+   - **TSNE layout** (`TsneLayoutStrategy`) – a vector reproduction of the raster tiles rendered by the Leaflet `/show` output map, from the same source data:
+     - Reads `tiles/<workspace>/config.json` for the current `set_id` and `state_hash`, then `tiles/<workspace>/<set_id>/config.json` for the grid, and refreshes whenever `state_hash` changes
+     - Grid positions are used verbatim: the half-cell stagger of odd rows is already baked into the published `pos[0]` values, so no extra hex offset is applied
+     - Items absent from the precalculated grid (added since the last recalculation) are hidden rather than approximated, so the view stays faithful to the tiles
+     - Per-item tilt comes from the grid's `metadata.rotate`, applied via `ThreeRendererService.setLayoutRotationOverrideEnabled()`; every other layout derives rotation from plausibility/favorable_future
+     - Cluster titles are overlaid by `TsneClustersOverlayComponent`, matching the output map: italic with a cream halo, tilted by `-average_rotation × 2`, coloured prefer-dark or prevent-dark by the sign of `average_rotation`, and sized to span the cluster so they scale with zoom
+     - Titles are localized with `TaxonomyService.localizeName()`, which follows the browser language (not the `lang` URL parameter)
    - Rejected items are excluded from showcase ingestion (`_private_moderation === 0` or `status === rejected`) and are not rendered in showcase-ws or output-map loops
    - User camera controls:
      - Pan: Click and drag to move around the canvas
@@ -139,12 +146,11 @@ The application uses Angular standalone components organized by feature:
    - Smooth camera animations with damping
    - QR code for easy mobile access
    - Random showcase mode to highlight photos
-    - **Permalink support**: Navigate to specific items via `item-id` parameter
-       - Example: `/showcase-ws?workspace=XXX&api_key=YYY&item-id=ZZZ&layout=svg`
-       - Camera automatically zooms and centers on the specified item
-    - **Layout aliases**: Friendly URL parameters for layout modes
-       - `layout=clusters` → Circle-packing layout
-       - `layout=themes` → Grid layout
+    - **URL state**: the active view, focused item and search text live in the URL *hash*, and are kept in sync as the user navigates
+       - Example: `/showcase-ws?workspace=XXX&api_key=YYY#view=tsne-grid&item=ZZZ&search=foo`
+       - `view` (or its alias `layout`) accepts the exact strategy keys: `svg`, `tsne`, `tsne-grid`, `circle-packing`
+       - `item` focuses an item – the camera zooms and centres on it
+       - Legacy forms are still accepted: a bare `#<view>` or a bare `#<item-id>`
    - **Access control**: Drag-to-edit only for users with admin_key
      - Visitors can view and click but not drag items
      - Editors with admin_key can drag and edit all items

--- a/documentation/EXTENDING.md
+++ b/documentation/EXTENDING.md
@@ -441,6 +441,56 @@ export class MyShowcaseComponent {
 </div>
 ```
 
+## Adding a Layout to Showcase WS
+
+A "view" in `/showcase-ws` is a `LayoutStrategy` that positions the same Three.js
+photo meshes. Adding one means writing the strategy and registering it in five
+places in `showcase-ws.component.ts`.
+
+### 1. Write the strategy
+
+Extend `LayoutStrategy` (`app/showcase-ws/layout-strategy.interface.ts`) and implement
+`getConfiguration()`, `getPositionForPhoto()` and `calculateAllPositions()`. Return
+`null` for a photo to hide it. Anything you put in `LayoutPosition.metadata` is merged
+into the photo's metadata, which is how a layout passes hints to the renderer.
+
+If the layout needs remote data, also implement `WebServiceLayoutStrategy` and do the
+fetching in `initialize()` — see `tsne-layout-strategy.ts`, which loads the
+precalculated t-SNE from `tiles/<workspace>/<set_id>/config.json`.
+
+### 2. Register the view
+
+```typescript
+// 1. The view union
+export type ShowcaseLayoutView = 'tsne' | 'tsne-grid' | 'svg' | 'circle-packing' | 'my-layout';
+const SHOWCASE_LAYOUT_VIEWS: readonly ShowcaseLayoutView[] = [/* …, */ 'my-layout'];
+
+// 2. A switcher, next to the existing switchToXxxLayout() methods
+public async switchToMyLayout() { /* set currentLayout, updateHashState, build + apply strategy */ }
+
+// 3. Dispatch from the hash, in applyHashStateFromUrl()
+// 4. Both initial-layout paths in ngAfterViewInit (before and after the first data load)
+// 5. A <button class='toggle-button'> in the .layout-toggle block of the template
+```
+
+Each switcher must also release the state owned by the view it replaces — see
+`clearTaxonomyOverlayState()` / `clearTsneGridState()`.
+
+### 3. Add an overlay (optional)
+
+To draw HTML on top of the scene, register a per-frame callback and project world
+coordinates yourself:
+
+```typescript
+this.rendererService.addFrameCallback(() => {
+  const screen = this.rendererService.worldToScreen(worldX, worldY);
+  el.style.transform = `translate(-50%, -50%) translate(${screen.x}px, ${screen.y}px)`;
+});
+```
+
+Run it inside `ngZone.runOutsideAngular()` so it does not trigger change detection on
+every frame. `taxonomy-clusters-overlay/` and `tsne-clusters-overlay/` are both examples.
+
 ## Adding Custom Fields to Workspaces
 
 Workspaces can have custom fields for collecting additional data.

--- a/projects/app/src/app/showcase-ws/showcase-ws.component.html
+++ b/projects/app/src/app/showcase-ws/showcase-ws.component.html
@@ -222,7 +222,25 @@
           <span class='button-label'>Thematic</span>
         </div>
       </button>
-      <button 
+      <button
+        class='toggle-button tsne-button'
+        [class.active]='currentLayout() === "tsne-grid"'
+        (click)='switchToTsneGridLayout()'
+        title='TSNE Layout'>
+        <div class='button-content'>
+          <svg viewBox='0 0 24 24' class='button-icon' aria-hidden='true'>
+            <circle cx='6' cy='7' r='1.8' fill='currentColor'/>
+            <circle cx='11' cy='4.5' r='1.8' fill='currentColor'/>
+            <circle cx='9' cy='12' r='1.8' fill='currentColor'/>
+            <circle cx='16' cy='9' r='1.8' fill='currentColor'/>
+            <circle cx='5' cy='17' r='1.8' fill='currentColor'/>
+            <circle cx='13' cy='18' r='1.8' fill='currentColor'/>
+            <circle cx='19' cy='15' r='1.8' fill='currentColor'/>
+          </svg>
+          <span class='button-label'>TSNE</span>
+        </div>
+      </button>
+      <button
         class='toggle-button clusters-button'
         [class.active]='currentLayout() === "circle-packing"'
         (click)='switchToCirclePackingLayout()'
@@ -258,6 +276,11 @@
     [zoomLevel]='currentZoomLevel()'
     (labelHover)='onTaxonomyLabelHover($event)'
   ></app-taxonomy-clusters-overlay>
+}
+
+<!-- TSNE cluster labels overlay (visible only in the TSNE layout) -->
+@if (currentLayout() === 'tsne-grid') {
+  <app-tsne-clusters-overlay [labels]='tsneClusterLabels()'></app-tsne-clusters-overlay>
 }
 
 @if (currentLayout() === 'tsne' && fisheyeEnabled() && fisheyeTaxonomyFocusLabel()) {

--- a/projects/app/src/app/showcase-ws/showcase-ws.component.less
+++ b/projects/app/src/app/showcase-ws/showcase-ws.component.less
@@ -280,11 +280,11 @@
                 opacity: 0.5;
                 position: relative;
                 
-                // Mobile responsive
+                // Mobile responsive – tightened so all four views fit on narrow screens
                 @media (max-width: 768px) {
-                    min-width: 90px;
+                    min-width: 72px;
                     height: 40px;
-                    padding: 0 12px;
+                    padding: 0 8px;
                     font-size: 12px;
                     border-radius: 18px;
                 }
@@ -385,6 +385,10 @@
                 }
 
                 &.thematic-button {
+                    border-radius: 23.5px;
+                }
+
+                &.tsne-button {
                     border-radius: 23.5px;
                 }
 

--- a/projects/app/src/app/showcase-ws/showcase-ws.component.ts
+++ b/projects/app/src/app/showcase-ws/showcase-ws.component.ts
@@ -15,6 +15,7 @@ import { LayoutStrategy } from './layout-strategy.interface';
 import { TaxonomyLayoutStrategy } from './taxonomy-layout-strategy';
 import { SvgBackgroundLayoutStrategy } from './svg-background-layout-strategy';
 import { CirclePackingLayoutStrategy } from './circle-packing-layout-strategy';
+import { TsneLayoutStrategy } from './tsne-layout-strategy';
 import { PhotoDataRepository } from './photo-data-repository';
 import { PHOTO_CONSTANTS } from './photo-constants';
 import { ANIMATION_CONSTANTS } from './animation-constants';
@@ -22,6 +23,19 @@ import { ApiService } from '../../api.service';
 import { TaxonomyClustersOverlayComponent } from './taxonomy-clusters-overlay/taxonomy-clusters-overlay.component';
 import { TaxonomyClusterLabel } from './taxonomy-clusters-overlay/taxonomy-label.interface';
 import { TaxonomyLabelHoverEvent } from './taxonomy-clusters-overlay/taxonomy-clusters-overlay.component';
+import { TsneClustersOverlayComponent } from './tsne-clusters-overlay/tsne-clusters-overlay.component';
+import { TsneClusterLabel } from './tsne-clusters-overlay/tsne-cluster-label.interface';
+
+/**
+ * The views offered by the layout toggle.
+ * - `svg` – Map
+ * - `tsne` – Thematic (taxonomy-driven, see TaxonomyLayoutStrategy)
+ * - `tsne-grid` – TSNE (server-precalculated embedding, see TsneLayoutStrategy)
+ * - `circle-packing` – Clusters
+ */
+export type ShowcaseLayoutView = 'tsne' | 'tsne-grid' | 'svg' | 'circle-packing';
+
+const SHOWCASE_LAYOUT_VIEWS: readonly ShowcaseLayoutView[] = ['tsne', 'tsne-grid', 'svg', 'circle-packing'];
 
 /** Duration of the drag_all countdown in minutes when first enabled. */
 const DRAG_ALL_DEFAULT_MINUTES = 5;
@@ -31,7 +45,7 @@ const DRAG_ALL_ALLOWED_PROPERTIES = 'layout_x,layout_y,plausibility,favorable_fu
 
 @Component({
   selector: 'app-showcase-ws',
-  imports: [QrcodeComponent, EvaluationSidebarComponent, FiltersBarComponent, TaxonomyClustersOverlayComponent],
+  imports: [QrcodeComponent, EvaluationSidebarComponent, FiltersBarComponent, TaxonomyClustersOverlayComponent, TsneClustersOverlayComponent],
   templateUrl: './showcase-ws.component.html',
   styleUrl: './showcase-ws.component.less'
 })
@@ -55,7 +69,7 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
   admin_key = signal('');
   lang = signal('');
   allowAdditionalContributions = signal(true); // Default to showing QR code
-  currentLayout = signal<'tsne' | 'svg' | 'circle-packing'>('circle-packing');
+  currentLayout = signal<ShowcaseLayoutView>('circle-packing');
   enableRandomShowcase = signal(false);
   enableSvgAutoPositioning = signal(true);
   fisheyeEnabled = signal(false);
@@ -67,6 +81,9 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
   taxonomySubThemeLabels = signal<TaxonomyClusterLabel[]>([]);
   /** Reference to the active TSNE layout strategy so we can query cluster positions. */
   private currentTsneStrategy: TaxonomyLayoutStrategy | null = null;
+
+  // Cluster labels for the TSNE layout, read from the server's t-SNE configuration.
+  tsneClusterLabels = signal<TsneClusterLabel[]>([]);
   
   // Evaluation sidebar state
   sidebarOpen = signal(false);
@@ -425,13 +442,17 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
         // If a hash-selected layout was already prepared before first load,
         // we still rerun TSNE once after data arrives so positions/cache are
         // populated from actual items (prevents empty thematic view on load).
+        const layoutNeedsRerun = this.currentLayout() === 'tsne' || this.currentLayout() === 'tsne-grid';
         const shouldSwitchAfterLoad = this.currentLayout() !== 'circle-packing'
-          && (!this.initialLayoutPreparedBeforeLoad || this.currentLayout() === 'tsne');
+          && (!this.initialLayoutPreparedBeforeLoad || layoutNeedsRerun);
         if (shouldSwitchAfterLoad) {
           try {
             switch (this.currentLayout()) {
               case 'tsne':
                 await this.switchToTsneLayout();
+                break;
+              case 'tsne-grid':
+                await this.switchToTsneGridLayout();
                 break;
               case 'svg':
                 await this.switchToSvgLayout();
@@ -1169,6 +1190,8 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
         try {
           if (this.currentLayout() === 'tsne') {
             await this.switchToTsneLayout();
+          } else if (this.currentLayout() === 'tsne-grid') {
+            await this.switchToTsneGridLayout();
           } else if (this.currentLayout() === 'svg') {
             await this.switchToSvgLayout();
           }
@@ -1237,7 +1260,8 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
       this.currentLayout.set('tsne');
       this.updateHashState({ view: 'tsne' });
       this.syncThematicFisheyeEffects();
-      
+      this.clearTsneGridState();
+
       // Create TSNE layout strategy with same dimensions as grid layout
       const tsneStrategy = new TaxonomyLayoutStrategy({
         photoWidth: PHOTO_CONSTANTS.PHOTO_WIDTH,
@@ -1265,6 +1289,79 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
     } finally {
       this.layoutChangeInProgress = false;
     }
+  }
+
+  /**
+   * Switch to the TSNE layout: the embedding precalculated server-side and
+   * published alongside the map tiles, the same data the Leaflet `/show` map
+   * renders. Items missing from the precalculated grid are hidden.
+   */
+  public async switchToTsneGridLayout() {
+    if (this.layoutChangeInProgress) {
+      return;
+    }
+
+    if (!this.workspace()) {
+      console.error('Workspace not set');
+      return;
+    }
+
+    this.layoutChangeInProgress = true;
+    try {
+      // Update UI immediately for responsive feedback
+      this.currentLayout.set('tsne-grid');
+      this.updateHashState({ view: 'tsne-grid' });
+      this.syncThematicFisheyeEffects();
+      this.clearTaxonomyOverlayState();
+
+      const tsneStrategy = new TsneLayoutStrategy(this.workspace(), undefined, {
+        photoWidth: PHOTO_CONSTANTS.PHOTO_WIDTH,
+        photoHeight: PHOTO_CONSTANTS.PHOTO_HEIGHT,
+        spacingX: PHOTO_CONSTANTS.SPACING_X,
+        spacingY: PHOTO_CONSTANTS.SPACING_Y
+      });
+
+      // Fetches the workspace config and the set's t-SNE configuration
+      await tsneStrategy.initialize();
+
+      // Remove SVG background if switching from SVG layout
+      this.rendererService.removeSvgBackground();
+      this.photoRepository.setSvgVisible(false);
+
+      // Use the server's per-item rotation so tilt matches the rendered tiles
+      this.rendererService.setLayoutRotationOverrideEnabled(true);
+
+      await this.photoRepository.setLayoutStrategy(tsneStrategy);
+
+      this.tsneClusterLabels.set(
+        tsneStrategy.getClustersWithWorldCoords().map((cluster, index) => ({
+          id: `tsne-cluster-${index}`,
+          name: this.taxonomyService.localizeName(cluster.title),
+          worldX: cluster.centerX,
+          worldY: cluster.centerY,
+          worldWidth: cluster.width,
+          rotationDeg: cluster.averageRotation,
+        }))
+      );
+    } catch (error) {
+      console.error('Error switching to TSNE layout:', error);
+    } finally {
+      this.layoutChangeInProgress = false;
+    }
+  }
+
+  /** Tear down state owned by the TSNE layout when leaving it. */
+  private clearTsneGridState(): void {
+    this.tsneClusterLabels.set([]);
+    this.rendererService.setLayoutRotationOverrideEnabled(false);
+  }
+
+  /** Tear down state owned by the Thematic layout when leaving it. */
+  private clearTaxonomyOverlayState(): void {
+    this.currentTsneStrategy = null;
+    this.taxonomyThemeLabels.set([]);
+    this.taxonomySubThemeLabels.set([]);
+    this.rendererService.resetTaxonomyHoverOpacityFocus();
   }
 
   /**
@@ -1347,12 +1444,9 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
       this.updateHashState({ view: 'svg' });
       this.syncThematicFisheyeEffects();
 
-      // Clear taxonomy overlay labels
-      this.currentTsneStrategy = null;
-      this.taxonomyThemeLabels.set([]);
-      this.taxonomySubThemeLabels.set([]);
-      this.rendererService.resetTaxonomyHoverOpacityFocus();
-      
+      this.clearTaxonomyOverlayState();
+      this.clearTsneGridState();
+
       // Read optional `svg` query param to override background path
       const svgParam = this.activatedRoute.snapshot.queryParams['svg'];
       const svgPath = svgParam || '/showcase-bg.svg';
@@ -1565,12 +1659,9 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
       this.updateHashState({ view: 'circle-packing' });
       this.syncThematicFisheyeEffects();
 
-      // Clear taxonomy overlay labels
-      this.currentTsneStrategy = null;
-      this.taxonomyThemeLabels.set([]);
-      this.taxonomySubThemeLabels.set([]);
-      this.rendererService.resetTaxonomyHoverOpacityFocus();
-      
+      this.clearTaxonomyOverlayState();
+      this.clearTsneGridState();
+
       // Create circle packing layout strategy
       const circlePackingStrategy = new CirclePackingLayoutStrategy({
         photoWidth: PHOTO_CONSTANTS.PHOTO_WIDTH,
@@ -2072,7 +2163,7 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
   }
 
   private parseHashState(): {
-    view?: 'tsne' | 'svg' | 'circle-packing';
+    view?: ShowcaseLayoutView;
     itemId?: string;
     search?: string;
   } {
@@ -2108,16 +2199,15 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
     };
   }
 
-  private normalizeLayout(layout: string | null): 'tsne' | 'svg' | 'circle-packing' | null {
+  private normalizeLayout(layout: string | null): ShowcaseLayoutView | null {
     if (!layout) return null;
-    if (layout === 'tsne' || layout === 'svg' || layout === 'circle-packing') {
-      return layout;
-    }
-    return null;
+    return SHOWCASE_LAYOUT_VIEWS.includes(layout as ShowcaseLayoutView)
+      ? layout as ShowcaseLayoutView
+      : null;
   }
 
   private updateHashState(patch: {
-    view?: 'tsne' | 'svg' | 'circle-packing' | null;
+    view?: ShowcaseLayoutView | null;
     itemId?: string | null;
     search?: string | null;
   }): void {
@@ -2178,6 +2268,8 @@ export class ShowcaseWsComponent implements AfterViewInit, OnDestroy {
     if (hashState.view && hashState.view !== this.currentLayout()) {
       if (hashState.view === 'tsne') {
         void this.switchToTsneLayout();
+      } else if (hashState.view === 'tsne-grid') {
+        void this.switchToTsneGridLayout();
       } else if (hashState.view === 'svg') {
         void this.switchToSvgLayout();
       } else {

--- a/projects/app/src/app/showcase-ws/three-renderer.service.ts
+++ b/projects/app/src/app/showcase-ws/three-renderer.service.ts
@@ -189,6 +189,7 @@ export class ThreeRendererService {
   private fisheyeAffectedMeshes = new Set<THREE.Mesh>();
   private topFisheyeMesh: THREE.Mesh | null = null;
   private thematicFisheyeEffectsEnabled = false;
+  private layoutRotationOverrideEnabled = false;
   private fisheyeLastDeltaTime = 1 / 60;
   private fisheyePointerActive = false;
   private taxonomyEffectBaseOpacity = new Map<THREE.Mesh, number>();
@@ -672,7 +673,17 @@ export class ThreeRendererService {
    */
   private calculatePhotoRotation(photoData: PhotoData): number {
     const metadata = photoData.metadata;
-    
+
+    // The TSNE layout supplies the server's own rotation for each item, so the
+    // view reproduces the rendered tiles exactly. Same convention as the formula
+    // below: positive = prefer, negative = prevent.
+    if (this.layoutRotationOverrideEnabled) {
+      const layoutRotateDeg = metadata['_tsneRotateDeg'];
+      if (typeof layoutRotateDeg === 'number') {
+        return THREE.MathUtils.degToRad(layoutRotateDeg);
+      }
+    }
+
     const plausibility = metadata['plausibility'];
     const favorableFuture = metadata['_svgZoneFavorableFuture'] as string | undefined || metadata['favorable_future'];
     
@@ -1036,6 +1047,30 @@ export class ThreeRendererService {
     if (!enabled) {
       this.resetFisheyeTaxonomyOpacityDimming();
     }
+  }
+
+  /**
+   * When enabled, photo rotation is taken from the layout-supplied
+   * `_tsneRotateDeg` metadata instead of being derived from the item's
+   * evaluation. Used by the TSNE layout so tilt matches the server-rendered
+   * tiles exactly.
+   *
+   * The flag is needed because layout metadata is merged into the photo
+   * permanently, so `_tsneRotateDeg` outlives a switch to another layout.
+   */
+  setLayoutRotationOverrideEnabled(enabled: boolean): void {
+    if (this.layoutRotationOverrideEnabled === enabled) return;
+    this.layoutRotationOverrideEnabled = enabled;
+    // Re-apply rotation to every existing mesh so the change is visible immediately.
+    this.meshToPhotoData.forEach((photoData, mesh) => {
+      mesh.rotation.z = this.calculatePhotoRotation(photoData);
+      // Keep any stashed pre-fisheye rotation in sync so restoring it doesn't
+      // resurrect the previous layout's tilt.
+      if (mesh.userData['originalRotation'] !== undefined) {
+        mesh.userData['originalRotation'] = mesh.rotation.z;
+      }
+    });
+    this.wakeUpRenderLoop();
   }
 
   /**

--- a/projects/app/src/app/showcase-ws/tsne-clusters-overlay/tsne-cluster-label.interface.ts
+++ b/projects/app/src/app/showcase-ws/tsne-clusters-overlay/tsne-cluster-label.interface.ts
@@ -1,0 +1,14 @@
+/** A t-SNE cluster label positioned in Three.js world space. */
+export interface TsneClusterLabel {
+  /** Unique identifier for the cluster. */
+  id: string;
+  /** Cluster title in the active locale. */
+  name: string;
+  /** Three.js world-space coordinates of the cluster centre. */
+  worldX: number;
+  worldY: number;
+  /** Width of the cluster region in world units – drives font size. */
+  worldWidth: number;
+  /** Mean item rotation (degrees) in the cluster – drives label tilt and colour. */
+  rotationDeg: number;
+}

--- a/projects/app/src/app/showcase-ws/tsne-clusters-overlay/tsne-clusters-overlay.component.html
+++ b/projects/app/src/app/showcase-ws/tsne-clusters-overlay/tsne-clusters-overlay.component.html
@@ -1,0 +1,5 @@
+<div class="tsne-cluster-labels-container" aria-hidden="true">
+  @for (label of labels(); track label.id) {
+    <div class="tsne-cluster-label" [class.prevent]="isPrevent(label)">{{ label.name }}</div>
+  }
+</div>

--- a/projects/app/src/app/showcase-ws/tsne-clusters-overlay/tsne-clusters-overlay.component.less
+++ b/projects/app/src/app/showcase-ws/tsne-clusters-overlay/tsne-clusters-overlay.component.less
@@ -1,0 +1,51 @@
+@import '../../../common.less';
+
+:host {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 50;
+}
+
+.tsne-cluster-labels-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.tsne-cluster-label {
+  .font-sans;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+  /* Initial transform applied before the first frame callback – keeps the label off-screen */
+  transform: translate(-50%, -50%) translate(-9999px, -9999px);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+  user-select: none;
+  white-space: nowrap;
+
+  font-style: italic;
+  font-weight: 400;
+  font-size: var(--label-font-size, 16px);
+  line-height: 1;
+  color: @color-prefer-dark;
+
+  /* Cream halo, standing in for the SVG `stroke` + `paint-order: stroke` used by
+     the output map – keeps titles readable over the item thumbnails. */
+  @halo: 0.12em;
+  text-shadow:
+    (-@halo) (-@halo) @halo @color-creme,
+    @halo (-@halo) @halo @color-creme,
+    (-@halo) @halo @halo @color-creme,
+    @halo @halo @halo @color-creme,
+    0 0 (@halo * 2) @color-creme;
+
+  &.prevent {
+    color: @color-prevent-dark;
+  }
+}

--- a/projects/app/src/app/showcase-ws/tsne-clusters-overlay/tsne-clusters-overlay.component.ts
+++ b/projects/app/src/app/showcase-ws/tsne-clusters-overlay/tsne-clusters-overlay.component.ts
@@ -1,0 +1,141 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  effect,
+  inject,
+  input,
+} from '@angular/core';
+import { TsneClusterLabel } from './tsne-cluster-label.interface';
+import { ThreeRendererService } from '../three-renderer.service';
+
+/**
+ * Renders t-SNE cluster labels as an HTML overlay on top of the Three.js canvas.
+ *
+ * Mirrors the look of the Leaflet `/show` output map: each label sits at its
+ * cluster's centre, tilts with the cluster's average item rotation, and is sized
+ * so it spans roughly the width of the cluster – meaning it scales with zoom
+ * rather than staying a fixed pixel size.
+ *
+ * The labels are decorative (`pointer-events: none`, `aria-hidden`); the items
+ * underneath remain the interactive layer.
+ */
+@Component({
+  selector: 'app-tsne-clusters-overlay',
+  templateUrl: './tsne-clusters-overlay.component.html',
+  styleUrl: './tsne-clusters-overlay.component.less',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TsneClustersOverlayComponent implements OnInit, OnDestroy {
+  /** Cluster labels to display, in world-space coordinates. */
+  labels = input<TsneClusterLabel[]>([]);
+
+  /** Font size bounds (px) so labels stay legible at extreme zoom levels. */
+  private static readonly MIN_FONT = 8;
+  private static readonly MAX_FONT = 120;
+
+  /**
+   * Width of the world-space segment used to measure the world→pixel scale.
+   * Roughly one grid cell, which keeps the measurement well away from
+   * floating-point noise.
+   */
+  private static readonly SCALE_PROBE_WORLD_UNITS = 1000;
+
+  /**
+   * Empirical constant from the output map: a title occupies about
+   * `length * 0.75` em of width, so this divisor makes the label span its cluster.
+   */
+  private static readonly EM_PER_CHARACTER = 0.75;
+
+  private rendererService = inject(ThreeRendererService);
+  private ngZone = inject(NgZone);
+  private el = inject(ElementRef<HTMLElement>);
+
+  private unregisterFrameCb: (() => void) | null = null;
+  /** Cached DOM elements for the current label set, in template order. */
+  private cachedLabelEls: HTMLElement[] = [];
+
+  constructor() {
+    // Invalidate the DOM element cache whenever the label set changes.
+    effect(() => {
+      this.labels();
+      Promise.resolve().then(() => this.refreshLabelCache());
+    });
+  }
+
+  ngOnInit(): void {
+    this.ngZone.runOutsideAngular(() => {
+      this.unregisterFrameCb = this.rendererService.addFrameCallback(() => {
+        this.updateLabelPositions();
+      });
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.unregisterFrameCb?.();
+    this.cachedLabelEls = [];
+  }
+
+  /** Clusters whose items lean towards "prevent" are rendered in the prevent colour. */
+  isPrevent(label: TsneClusterLabel): boolean {
+    return label.rotationDeg <= 0;
+  }
+
+  private refreshLabelCache(): void {
+    const host = this.el.nativeElement as HTMLElement;
+    this.cachedLabelEls = Array.from(host.querySelectorAll<HTMLElement>('.tsne-cluster-label'));
+    this.updateLabelPositions();
+  }
+
+  /**
+   * Projects each label to its screen position, scales its font with the current
+   * zoom and hides labels whose anchor has left the viewport.
+   */
+  private updateLabelPositions(): void {
+    const labels = this.labels();
+    const els = this.cachedLabelEls;
+    if (els.length === 0) return;
+
+    const scale = this.getWorldToScreenScale();
+    if (scale === null) return;
+
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const { MIN_FONT, MAX_FONT, EM_PER_CHARACTER } = TsneClustersOverlayComponent;
+
+    for (let i = 0; i < els.length; i++) {
+      const label = labels[i];
+      const el = els[i];
+      if (!label) continue;
+
+      const screen = this.rendererService.worldToScreen(label.worldX, label.worldY);
+      if (!screen || screen.x < 0 || screen.x > vw || screen.y < 0 || screen.y > vh) {
+        el.style.opacity = '0';
+        continue;
+      }
+
+      const charCount = Math.max(1, label.name.length);
+      const fontPx = Math.min(
+        MAX_FONT,
+        Math.max(MIN_FONT, (label.worldWidth / (charCount * EM_PER_CHARACTER)) * scale)
+      );
+
+      el.style.setProperty('--label-font-size', `${fontPx}px`);
+      el.style.transform =
+        `translate(-50%, -50%) translate(${screen.x}px, ${screen.y}px) rotate(${-label.rotationDeg * 2}deg)`;
+      el.style.opacity = '1';
+    }
+  }
+
+  /** Pixels per world unit at the current camera position, or null if unavailable. */
+  private getWorldToScreenScale(): number | null {
+    const probe = TsneClustersOverlayComponent.SCALE_PROBE_WORLD_UNITS;
+    const origin = this.rendererService.worldToScreen(0, 0);
+    const offset = this.rendererService.worldToScreen(probe, 0);
+    if (!origin || !offset) return null;
+    return Math.abs(offset.x - origin.x) / probe;
+  }
+}

--- a/projects/app/src/app/showcase-ws/tsne-layout-strategy.ts
+++ b/projects/app/src/app/showcase-ws/tsne-layout-strategy.ts
@@ -4,8 +4,13 @@ import { Observable, from } from 'rxjs';
 import { PHOTO_CONSTANTS } from './photo-constants';
 
 /**
- * TSNE Layout Strategy that fetches positioning data from a remote configuration service
- * and positions photos according to TSNE (t-Distributed Stochastic Neighbor Embedding) algorithm results.
+ * TSNE Layout Strategy that positions photos according to the t-SNE embedding
+ * precalculated server-side and published alongside the map tiles.
+ *
+ * The same data backs the raster tiles rendered by the Leaflet `/show` output map,
+ * so this layout is a vector reproduction of that view inside the Three.js scene.
+ * Items that are absent from the precalculated grid (e.g. added after the last
+ * recalculation) are hidden rather than approximated.
  */
 export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayoutStrategy {
   private workspaceConfigUrl: string;
@@ -39,7 +44,7 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
   ) {
     super();
     this.workspaceConfigUrl = `${this.baseUrl}/tiles/${this.workspaceId}/config.json`;
-    
+
     // Use same dimensions as grid layout to ensure consistency
     this.photoWidth = options.photoWidth ?? PHOTO_CONSTANTS.PHOTO_WIDTH;
     this.photoHeight = options.photoHeight ?? PHOTO_CONSTANTS.PHOTO_HEIGHT;
@@ -56,7 +61,6 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
     await super.initialize();
     // Always refresh data when switching to TSNE layout to ensure we have the latest data
     await this.forceRefresh();
-
   }
 
   /**
@@ -64,9 +68,9 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
    */
   getConfiguration(): LayoutConfiguration {
     return {
-      name: 'tsne',
+      name: 'tsne-grid',
       displayName: 'TSNE Layout',
-      description: 'Positions photos using TSNE coordinates from a web service with proper spacing',
+      description: 'Positions photos on the server-precalculated t-SNE grid',
       supportsInteraction: false,
       requiresWebService: true,
       settings: {
@@ -99,17 +103,17 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
   private async fetchWorkspaceConfig(): Promise<WorkspaceConfig> {
     try {
       const response = await fetch(this.workspaceConfigUrl);
-      
+
       if (!response.ok) {
         throw new Error(`Failed to fetch workspace config: ${response.status} ${response.statusText}`);
       }
 
       const data = await response.json();
-      
+
       if (typeof data.set_id !== 'number') {
         throw new Error('Invalid workspace config: missing or invalid set_id: ' + data.set_id + ' ' + typeof data.set_id);
       }
-      
+
       if (!data.state_hash || typeof data.state_hash !== 'string') {
         throw new Error('Invalid workspace config: missing or invalid state_hash: ' + data.state_hash);
       }
@@ -134,7 +138,7 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
 
     this.isLoading = true;
     this.loadPromise = this.doFetchTsneData();
-    
+
     try {
       await this.loadPromise;
     } finally {
@@ -146,31 +150,26 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
     try {
       // First, fetch workspace configuration to get set_id and state_hash
       const workspaceConfig = await this.fetchWorkspaceConfig();
-      
+
       // Check if we need to refresh based on state_hash
       if (this.currentStateHash === workspaceConfig.state_hash && this.tsneData) {
-
         return;
       }
-      
+
       // Update our tracking variables
       this.currentStateHash = workspaceConfig.state_hash;
       this.currentSetId = workspaceConfig.set_id;
       this.tsneConfigUrl = `${this.baseUrl}/tiles/${this.workspaceId}/${workspaceConfig.set_id}/config.json`;
-      
 
-      
       // Now fetch the actual TSNE configuration
       const response = await fetch(this.tsneConfigUrl);
-      
+
       if (!response.ok) {
         throw new Error(`Failed to fetch TSNE config: ${response.status} ${response.statusText}`);
       }
 
       const data = await response.json();
       this.tsneData = this.validateTsneConfig(data);
-      
-
     } catch (error) {
       console.error('Error fetching TSNE configuration:', error);
       throw error;
@@ -199,11 +198,11 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
       if (!item || typeof item !== 'object') {
         throw new Error(`Invalid TSNE config: grid item ${i} is not an object`);
       }
-      
+
       if (!Array.isArray(item.pos) || item.pos.length !== 2) {
         throw new Error(`Invalid TSNE config: grid item ${i} pos must be an array of 2 numbers`);
       }
-      
+
       if (typeof item.id !== 'string') {
         throw new Error(`Invalid TSNE config: grid item ${i} id must be a string`);
       }
@@ -214,53 +213,30 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
       grid: data.grid as TsneGridItem[],
       padding_ratio: data.padding_ratio || 0.5,
       conversion_ratio: data.conversion_ratio || [1, 1],
-      cell_ratios: data.cell_ratios || [1, 1]
+      cell_ratios: data.cell_ratios || [1, 1],
+      clusters: Array.isArray(data.clusters) ? data.clusters as TsneClusterItem[] : []
     };
   }
 
   /**
-   * Gets the position for a photo based on TSNE coordinates
+   * Gets the position for a photo based on TSNE coordinates.
+   * Returns null (i.e. hides the photo) for items missing from the precalculated grid.
    */
-  async getPositionForPhoto(photo: PhotoData, existingPhotos: PhotoData[]): Promise<LayoutPosition | null> {
+  async getPositionForPhoto(photo: PhotoData): Promise<LayoutPosition | null> {
     // Ensure TSNE data is loaded
     await this.fetchTsneData();
-    
+
     if (!this.tsneData) {
       throw new Error('TSNE data not available');
     }
 
-    // Find the photo in the TSNE grid data by matching ID
     const gridItem = this.tsneData.grid.find(item => item.id === photo.id);
-    
     if (!gridItem) {
-      const fallbackWorldPos = this.getFallbackWorldPosition(photo, existingPhotos);
-      if (fallbackWorldPos) {
-        return {
-          x: fallbackWorldPos.x,
-          y: fallbackWorldPos.y,
-          gridKey: `tsne-fallback-${photo.id}`,
-          metadata: {
-            tsneFallback: true,
-            tsneMissingId: photo.id,
-          }
-        };
-      }
-
-      // Last-resort fallback: place near layout center instead of hiding.
-      const centerJitter = this.getDeterministicJitter(photo.id, Math.min(this.cellW, this.cellH) * 0.35);
-      return {
-        x: centerJitter.x,
-        y: centerJitter.y,
-        gridKey: `tsne-fallback-center-${photo.id}`,
-        metadata: {
-          tsneFallback: true,
-          tsneMissingId: photo.id,
-        }
-      };
+      return null;
     }
 
-    // Convert TSNE grid coordinates to world coordinates
     const worldPos = this.convertTsneToWorldCoordinates(gridItem.pos, this.tsneData.dim);
+    const rotateDeg = gridItem.metadata?.rotate;
 
     return {
       x: worldPos.x,
@@ -268,107 +244,10 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
       gridKey: `tsne-${gridItem.pos[0]}-${gridItem.pos[1]}`,
       metadata: {
         tsnePosition: gridItem.pos,
-        originalMetadata: gridItem.metadata
+        // Consumed by ThreeRendererService when the layout rotation override is enabled,
+        // so item tilt matches the server-rendered tiles exactly.
+        _tsneRotateDeg: typeof rotateDeg === 'number' ? rotateDeg : undefined,
       }
-    };
-  }
-
-  /**
-   * Compute a fallback world position for items missing from TSNE grid data.
-   * Strategy:
-   * 1) Place near centroid of mapped items sharing the same topic.
-   * 2) Else place near centroid of mapped items sharing the same theme.
-    * 3) Else place near the global centroid of all mapped items.
-    * 4) Else return null and let caller use center fallback.
-   */
-  private getFallbackWorldPosition(photo: PhotoData, existingPhotos: PhotoData[]): { x: number; y: number } | null {
-    if (!this.tsneData) return null;
-
-    const mappedById = new Set(this.tsneData.grid.map(item => item.id));
-    const topicCentroids = new Map<string, { sumX: number; sumY: number; count: number }>();
-    const themeCentroids = new Map<string, { sumX: number; sumY: number; count: number }>();
-
-    const globalAccumulator = { sumX: 0, sumY: 0, count: 0 };
-
-    for (const existing of existingPhotos) {
-      if (!mappedById.has(existing.id)) continue;
-      const world = this.getWorldPositionForId(existing.id);
-      if (!world) continue;
-
-      globalAccumulator.sumX += world.x;
-      globalAccumulator.sumY += world.y;
-      globalAccumulator.count += 1;
-
-      const topics: string[] = (existing.metadata['topics'] as string[]) || [];
-      const uniqueTopics = new Set(topics);
-
-      for (const topic of uniqueTopics) {
-        const topicAcc = topicCentroids.get(topic) ?? { sumX: 0, sumY: 0, count: 0 };
-        topicAcc.sumX += world.x;
-        topicAcc.sumY += world.y;
-        topicAcc.count += 1;
-        topicCentroids.set(topic, topicAcc);
-
-        const theme = topic.split('/')[0];
-        const themeAcc = themeCentroids.get(theme) ?? { sumX: 0, sumY: 0, count: 0 };
-        themeAcc.sumX += world.x;
-        themeAcc.sumY += world.y;
-        themeAcc.count += 1;
-        themeCentroids.set(theme, themeAcc);
-      }
-    }
-
-    const photoTopics: string[] = (photo.metadata['topics'] as string[]) || [];
-    for (const topic of photoTopics) {
-      const acc = topicCentroids.get(topic);
-      if (acc && acc.count > 0) {
-        const center = { x: acc.sumX / acc.count, y: acc.sumY / acc.count };
-        const jitter = this.getDeterministicJitter(photo.id, Math.min(this.cellW, this.cellH) * 0.22);
-        return { x: center.x + jitter.x, y: center.y + jitter.y };
-      }
-    }
-
-    for (const topic of photoTopics) {
-      const theme = topic.split('/')[0];
-      const acc = themeCentroids.get(theme);
-      if (acc && acc.count > 0) {
-        const center = { x: acc.sumX / acc.count, y: acc.sumY / acc.count };
-        const jitter = this.getDeterministicJitter(photo.id, Math.min(this.cellW, this.cellH) * 0.3);
-        return { x: center.x + jitter.x, y: center.y + jitter.y };
-      }
-    }
-
-    // Non-evaluated / topic-less items: anchor to overall mapped cloud with stable jitter.
-    if (globalAccumulator.count > 0) {
-      const center = {
-        x: globalAccumulator.sumX / globalAccumulator.count,
-        y: globalAccumulator.sumY / globalAccumulator.count,
-      };
-      const jitter = this.getDeterministicJitter(photo.id, Math.min(this.cellW, this.cellH) * 0.35);
-      return { x: center.x + jitter.x, y: center.y + jitter.y };
-    }
-
-    return null;
-  }
-
-  /**
-   * Stable pseudo-random offset based on item ID to avoid overlap while staying deterministic.
-   */
-  private getDeterministicJitter(id: string, radius: number): { x: number; y: number } {
-    let hash = 0;
-    for (let i = 0; i < id.length; i++) {
-      hash = ((hash << 5) - hash) + id.charCodeAt(i);
-      hash |= 0;
-    }
-
-    const seedA = Math.abs(hash);
-    const seedB = Math.abs(hash * 1103515245 + 12345);
-    const angle = (seedA % 360) * (Math.PI / 180);
-    const dist = ((seedB % 1000) / 1000) * radius;
-
-    return {
-      x: Math.cos(angle) * dist,
-      y: Math.sin(angle) * dist,
     };
   }
 
@@ -377,141 +256,16 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
    */
   async calculateAllPositions(photos: PhotoData[]): Promise<(LayoutPosition | null)[]> {
     await this.fetchTsneData();
-    
+
     if (!this.tsneData) {
       throw new Error('TSNE data not available');
     }
 
     const positions: (LayoutPosition | null)[] = [];
-    
     for (const photo of photos) {
-      const position = await this.getPositionForPhoto(photo, photos);
-      positions.push(position);
+      positions.push(await this.getPositionForPhoto(photo));
     }
-
-    return this.resolvePositionOverlaps(photos, positions);
-  }
-
-  /**
-   * Ensure each item occupies a unique visual slot by spreading coordinate collisions
-   * along a deterministic hex spiral around their shared base position.
-   */
-  private resolvePositionOverlaps(
-    photos: PhotoData[],
-    positions: (LayoutPosition | null)[]
-  ): (LayoutPosition | null)[] {
-    if (!this.tsneData) return positions;
-
-    const dim = this.tsneData.dim;
-    const resolved = positions.map(p => (p ? { ...p, metadata: p.metadata ? { ...p.metadata } : undefined } : null));
-    const occupied = new Set<string>();
-
-    const indices = resolved
-      .map((p, index) => ({ p, index }))
-      .filter(entry => !!entry.p)
-      // Prefer explicit TSNE positions first, then stable by ID for deterministic output.
-      .sort((a, b) => {
-        const aHasTsnePos = Array.isArray(a.p!.metadata?.['tsnePosition']) ? 1 : 0;
-        const bHasTsnePos = Array.isArray(b.p!.metadata?.['tsnePosition']) ? 1 : 0;
-        if (aHasTsnePos !== bHasTsnePos) return bHasTsnePos - aHasTsnePos;
-        return photos[a.index].id.localeCompare(photos[b.index].id);
-      })
-      .map(entry => entry.index);
-
-    for (const index of indices) {
-      const position = resolved[index];
-      if (!position) continue;
-
-      const desired = this.getDesiredGridCoord(position, dim);
-      const assigned = this.findNearestFreeGridCoord(desired, occupied);
-      occupied.add(this.gridCoordKey(assigned));
-
-      const world = this.convertTsneToWorldCoordinates([assigned.x, assigned.y], dim);
-      position.x = world.x;
-      position.y = world.y;
-      position.gridKey = `tsne-${assigned.x}-${assigned.y}`;
-      position.metadata = {
-        ...(position.metadata || {}),
-        tsneAssignedGridPos: [assigned.x, assigned.y],
-      };
-    }
-
-    return resolved;
-  }
-
-  /**
-   * Determine the desired integer grid coordinate for a position.
-   * Uses native TSNE grid position when available; otherwise rounds from world-space.
-   */
-  private getDesiredGridCoord(position: LayoutPosition, dim: [number, number]): { x: number; y: number } {
-    const tsnePosition = position.metadata?.['tsnePosition'];
-    if (Array.isArray(tsnePosition) && tsnePosition.length === 2) {
-      return {
-        x: Math.round(Number(tsnePosition[0])),
-        y: Math.round(Number(tsnePosition[1])),
-      };
-    }
-
-    return this.worldToGridCoordinates(position.x, position.y, dim);
-  }
-
-  /** Convert world coordinates back to nearest integer TSNE grid coordinate. */
-  private worldToGridCoordinates(worldX: number, worldY: number, dim: [number, number]): { x: number; y: number } {
-    const [maxGridX, maxGridY] = dim;
-    const centerOffsetX = (maxGridX - 1) * this.cellW / 2 + this.cellW / 4;
-    const centerOffsetY = (maxGridY - 1) * this.cellH / 2;
-
-    // Estimate gridY first, then correct for the hex row offset when computing gridX.
-    const gridY = Math.round((centerOffsetY - worldY) / this.cellH);
-    const hexOffsetX = (gridY % 2 !== 0) ? this.cellW / 2 : 0;
-    const gridX = Math.round((worldX + centerOffsetX - hexOffsetX) / this.cellW);
-
-    return { x: gridX, y: gridY };
-  }
-
-  /** Find the nearest unoccupied grid coordinate using deterministic hex-spiral expansion. */
-  private findNearestFreeGridCoord(
-    desired: { x: number; y: number },
-    occupied: Set<string>
-  ): { x: number; y: number } {
-    const desiredKey = this.gridCoordKey(desired);
-    if (!occupied.has(desiredKey)) return desired;
-
-    let ring = 1;
-    while (ring < 1024) {
-      let q = desired.x - ring;
-      let r = desired.y + ring;
-
-      const dirs: ReadonlyArray<readonly [number, number]> = [
-        [1, 0],
-        [1, -1],
-        [0, -1],
-        [-1, 0],
-        [-1, 1],
-        [0, 1],
-      ];
-
-      for (let d = 0; d < dirs.length; d++) {
-        const [dq, dr] = dirs[d];
-        for (let step = 0; step < ring; step++) {
-          const candidate = { x: q, y: r };
-          if (!occupied.has(this.gridCoordKey(candidate))) {
-            return candidate;
-          }
-          q += dq;
-          r += dr;
-        }
-      }
-
-      ring += 1;
-    }
-
-    // Should be practically unreachable; keeps function total in pathological cases.
-    return { x: desired.x, y: desired.y + 2048 };
-  }
-
-  private gridCoordKey(coord: { x: number; y: number }): string {
-    return `${coord.x}:${coord.y}`;
+    return positions;
   }
 
   /**
@@ -523,27 +277,26 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
 
   /**
    * Converts TSNE grid coordinates to Three.js world coordinates.
-   * Uses a hexbin (offset-row) layout: odd rows are shifted right by half
-   * a cell width to produce the classic brick/beehive stagger.
+   *
+   * The layout is a hexbin (offset-row) grid, but the half-cell stagger of odd
+   * rows is already baked into the published `pos[0]` values (odd rows end in
+   * `.5`), so no extra offset is applied here.
    */
   private convertTsneToWorldCoordinates(
-    tsnePos: [number, number], 
+    tsnePos: [number, number],
     gridDim: [number, number]
   ): { x: number; y: number } {
     const [gridX, gridY] = tsnePos;
     const [maxGridX, maxGridY] = gridDim;
-    
-    // Hexbin offset: odd rows are shifted right by half a cell width.
-    const hexOffsetX = (Math.round(gridY) % 2 !== 0) ? this.cellW / 2 : 0;
 
     // Center the grid around origin. The extra cellW/4 accounts for the average
     // half-cell shift across odd/even rows so the overall layout stays centred.
     const centerOffsetX = (maxGridX - 1) * this.cellW / 2 + this.cellW / 4;
     const centerOffsetY = (maxGridY - 1) * this.cellH / 2;
-    
-    const worldX = gridX * this.cellW + hexOffsetX - centerOffsetX;
+
+    const worldX = gridX * this.cellW - centerOffsetX;
     const worldY = centerOffsetY - gridY * this.cellH; // Flip Y axis for screen coordinates
-    
+
     return { x: worldX, y: worldY };
   }
 
@@ -552,47 +305,46 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
    */
   private async getAllPositionsAsMap(photos: PhotoData[]): Promise<{ [photoId: string]: LayoutPosition | null }> {
     await this.fetchTsneData();
-    
+
     if (!this.tsneData) {
       throw new Error('TSNE data not available');
     }
 
     const positions: { [photoId: string]: LayoutPosition | null } = {};
-    
     for (const photo of photos) {
-      const position = await this.getPositionForPhoto(photo, photos);
-      positions[photo.id] = position;
+      positions[photo.id] = await this.getPositionForPhoto(photo);
     }
-    
     return positions;
   }
-  
+
   /**
    * Gets the layout bounds based on TSNE data
    */
   async getLayoutBounds(): Promise<{ width: number; height: number }> {
     await this.fetchTsneData();
-    
+
     if (!this.tsneData) {
       return { width: this.cellW * 10, height: this.cellH * 10 }; // Default fallback
     }
 
     // Calculate dimensions based on TSNE grid size using actual cell dimensions
     const [maxGridX, maxGridY] = this.tsneData.dim;
-    
+
     // Extra cellW/2 for the hex row offset on odd rows.
     const width = maxGridX * this.cellW + this.cellW / 2;
     const height = maxGridY * this.cellH;
-    
+
     return { width, height };
-  }  /**
+  }
+
+  /**
    * Updates the workspace ID and reloads TSNE data
    */
   async setWorkspaceId(workspaceId: string): Promise<void> {
     if (this.workspaceId === workspaceId) {
       return;
     }
-    
+
     this.workspaceId = workspaceId;
     this.workspaceConfigUrl = `${this.baseUrl}/tiles/${this.workspaceId}/config.json`;
     this.tsneData = null;
@@ -601,7 +353,7 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
     this.tsneConfigUrl = null;
     this.isLoading = false;
     this.loadPromise = null;
-    
+
     // Preload new data
     await this.fetchTsneData();
   }
@@ -620,7 +372,7 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
     if (!this.tsneData) {
       return null;
     }
-    
+
     return {
       workspaceId: this.workspaceId,
       gridSize: this.tsneData.dim,
@@ -634,7 +386,7 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
 
   /**
    * Returns the world-space position for an item by its ID, or null if not found.
-   * Requires that TSNE data has been loaded (call fetchTsneData / initialize first).
+   * Requires that TSNE data has been loaded (call initialize() first).
    */
   getWorldPositionForId(id: string): { x: number; y: number } | null {
     if (!this.tsneData) return null;
@@ -645,7 +397,7 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
 
   /**
    * Returns the cluster regions defined in the TSNE configuration, converted to
-   * world-space centre coordinates and approximate sizes.
+   * world-space centre coordinates and sizes.
    * Returns an empty array if no clusters are defined or data has not been loaded.
    */
   getClustersWithWorldCoords(): TsneClusterWithWorldCoords[] {
@@ -653,17 +405,14 @@ export class TsneLayoutStrategy extends LayoutStrategy implements WebServiceLayo
     const dim = this.tsneData.dim;
     return this.tsneData.clusters.map(cluster => {
       const [[x1, y1], [x2, y2]] = cluster.bounds;
-      const gridCenterX = (x1 + x2) / 2;
-      const gridCenterY = (y1 + y2) / 2;
-      const center = this.convertTsneToWorldCoordinates([gridCenterX, gridCenterY], dim);
-      const topLeft = this.convertTsneToWorldCoordinates([x1, y1], dim);
-      const bottomRight = this.convertTsneToWorldCoordinates([x2, y2], dim);
+      const center = this.convertTsneToWorldCoordinates([(x1 + x2) / 2, (y1 + y2) / 2], dim);
       return {
         title: cluster.title,
         centerX: center.x,
         centerY: center.y,
-        halfW: Math.abs(bottomRight.x - topLeft.x) / 2,
-        halfH: Math.abs(bottomRight.y - topLeft.y) / 2,
+        width: Math.abs(x2 - x1) * this.cellW,
+        height: Math.abs(y2 - y1) * this.cellH,
+        averageRotation: cluster.average_rotation ?? 0,
       };
     });
   }
@@ -678,7 +427,7 @@ interface TsneConfigData {
   padding_ratio: number;
   conversion_ratio: [number, number];
   cell_ratios: [number, number];
-  clusters?: TsneClusterItem[];
+  clusters: TsneClusterItem[];
 }
 
 /**
@@ -699,9 +448,11 @@ export interface TsneClusterWithWorldCoords {
   /** Center of the cluster in Three.js world coordinates */
   centerX: number;
   centerY: number;
-  /** Approximate half-width/height of the cluster region in world units */
-  halfW: number;
-  halfH: number;
+  /** Size of the cluster region in world units */
+  width: number;
+  height: number;
+  /** Mean item rotation (degrees) within the cluster – drives label tilt and colour */
+  averageRotation: number;
 }
 
 /**


### PR DESCRIPTION
Adds a fourth view to the `/showcase-ws` layout toggle — **TSNE** — that renders the t-SNE precalculated server-side and published alongside the map tiles, with the cluster titles overlaid.

It's a vector reproduction of what the Leaflet `/show` output map renders as raster tiles, inside the existing Three.js scene:

| | |
|---|---|
| Placement | Fourth toggle button (`Map / Thematic / TSNE / Clusters`); **Thematic** is unchanged |
| Data | `tiles/<workspace>/config.json` → `set_id`, then `tiles/<workspace>/<set_id>/config.json` |
| Item rotation | The grid's `metadata.rotate`, so tilt matches the tiles exactly |
| Items missing from the grid | Hidden — the view stays faithful to the precalculated layout |
| Cluster labels | Italic with a cream halo, tilted by `-average_rotation × 2`, coloured by its sign, sized to span the cluster so they scale with zoom |
| URL state | `#view=tsne-grid` |

## Two bugs found in `TsneLayoutStrategy`

The class already existed but was dead code (no importers — the `tsne` view slot uses `TaxonomyLayoutStrategy`), and had drifted from the data it reads:

1. `convertTsneToWorldCoordinates()` added a half-cell offset to odd rows, but the published `pos[0]` values already carry that stagger (odd rows end in `.5`) — so every odd row was shifted a full cell instead of half a cell.
2. All positions were then snapped to integer cells by a hex-spiral collision resolver, which would have destroyed those `.5` offsets anyway. That machinery — along with the topic/theme centroid fallback for unmapped items — is removed: the published grid has no duplicate positions, and unmapped items are now hidden.

`validateTsneConfig()` also dropped the `clusters` array even though the type declared it, so cluster labels were never available.

## Other changes

- `ThreeRendererService.setLayoutRotationOverrideEnabled()` lets a layout supply per-item rotation. Gated on a flag rather than on the metadata alone, because layout metadata is merged into the photo permanently and would otherwise outlive the view.
- New `TsneClustersOverlayComponent`, using the same per-frame `worldToScreen` projection as the taxonomy overlay.
- The layout union that was repeated in five places is now a `ShowcaseLayoutView` type, and the duplicated overlay teardown in each switcher is folded into `clearTaxonomyOverlayState()` / `clearTsneGridState()`.
- Docs: ARCHITECTURE.md described "TSNE / Thematic" as a single layout — now split into the four views the toggle actually offers. Its URL-state section was also stale (`layout=clusters` / `layout=themes` aliases don't exist, and the state lives in the hash) — corrected. EXTENDING.md gains a section on adding a layout to showcase-ws.

## Verification

Checked side by side against `/show` for the same workspace: item positions, tilt, and cluster label placement/colour/size line up. Labels scale with zoom and stay anchored; switching between all four views clears state cleanly and rotation reverts outside TSNE; no console errors; `npm run build` clean.

There are no automated tests for `showcase-ws` (see TESTING.md — it's manually verified).

## Worth knowing

- **133 of the workspace's 222 items are hidden in this view** — the precalculated grid contains only 89, the same 89 the `/show` tiles render. Faithful to the tiles, but the gap will grow between recalculations.
- **Cluster titles follow the browser language, not `?lang=`.** They use the shared `TaxonomyService.localizeName()`, same as the Thematic overlay.

fixes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)